### PR TITLE
Result Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 let data = Iter.fromArray<Nat8>(Blob.toArray(Text.encodeUtf8(
     "Text or something else that can be converted to bytes.",
 )));
+
 let reader = IO.fromIter(data);
-let (bs, n, err) = IO.readAll(reader);
-// ([...], 54, "")
+switch (IO.readAll(reader)) {
+    case (#ok(bs)) // [...].size() == 54.
+    ...
+};
+
 ```

--- a/src/IO.mo
+++ b/src/IO.mo
@@ -6,8 +6,12 @@ import Text "mo:base/Text";
 
 module {
     public type Result<T> = {
+        // Read was successful.
         #ok  : T;
+        // Read was successful, but encoutered an EOF.
+        // No more data is available in the reader.
         #eof : T;
+        // Read was unsuccessful. E.g. insufficient/no more data available.
         #err : (T, Error);
     };
 
@@ -19,7 +23,6 @@ module {
     // EOF is the error returned by Read when no more input is available.
     public let EOF : Error = "EOF";
     public let unexpectedEOF : Error = "unexpectedEOF";
-    private let noErr : Error = "";
 
     public type Reader<T> = {
         // Reads up to n bytes into a new array. It returns the bytes read (0 <= _ <= n) and any error encountered.
@@ -103,7 +106,7 @@ module {
                 switch (iter.next()) {
                     case (null) {
                         // This should never happen (unreachable?).
-                        return #err([], "from iter: could not get value");
+                        return #err(b, unexpectedEOF);
                     };
                     case (? v) {
                         b := Array.append(b, [v]);

--- a/test/Reader.mo
+++ b/test/Reader.mo
@@ -10,15 +10,27 @@ func range(n : Nat, m : Nat) : Iter.Iter<Nat8> {
 do {
     let r = IO.fromIter(range(0, 100));
 
-    assert(r.read(1) == ([0], ""));
-    assert(r.read(5) == ([1, 2, 3, 4, 5], ""));
-    assert(IO.readAtLeast(r, 10, 15) == (Iter.toArray(range(6, 20)), ""));
-    assert(IO.readFull(r, 40).0.size() == 40);
-    assert(IO.readAll(r).0.size() == 40);
+    assert(r.read(1) == #ok([0]));
+    assert(r.read(5) == #ok([1, 2, 3, 4, 5]));
+    assert(IO.readAtLeast(r, 10, 15) == #ok(Iter.toArray(range(6, 20))));
+    switch (IO.readFull(r, 40)) {
+        case (#ok(b)) assert(b.size() == 40);
+        case (_)      assert(false);
+    };
+    switch (IO.readAll(r)) {
+        case (#ok(b)) assert(b.size() == 40);
+        case (_)      assert(false);
+    }
 };
 
 do {
     let data = range(0, 9);
     let r = IO.fromIter(data);
-    assert(IO.readFull(r, 100) == (Iter.toArray(range(0, 9)), IO.unexpectedEOF));
+    switch (IO.readFull(r, 100)) {
+        case (#err(b, e)) {
+            assert(b == Iter.toArray(range(0, 9)));
+            assert(e == IO.unexpectedEOF);
+        };
+        case (_) assert(false);
+    };
 };


### PR DESCRIPTION
Use a result type instead of tuple:

```
+ read(n : Nat) : Result<[T]>;
- read(n : Nat) : ([T], Error);
```

```
public type Result<T> = {
    #ok  : T;
    #eof : T;
    #err : (T, Error);
};
```